### PR TITLE
Replace source zshrc with exec zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bundle # it will ask for your password.
 
 ```bash
 echo 'alias norminette="~/.norminette/norminette.rb"' >> ~/.zshrc
-source ~/.zshrc
+exec zsh
 ```
 <br /><br />
 ### GNU/Linux
@@ -46,7 +46,7 @@ bundle
 
 ```bash
 echo 'alias norminette="~/.norminette/norminette.rb"' >> ~/.zshrc
-source ~/.zshrc
+exec zsh
 ```
 <br /><br />
 ### Windows


### PR DESCRIPTION
This is a fix for an issue which is mentioned on ohmyzsh
cf. ohmyzsh/ohmyzsh/issues/5243