### PR TITLE
update README.md: add deprecated note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Important Note
+
+This project is no longer supported by 42. This version of Norminette concerns the V2 version of the 42 Network's most beloved linter. If you are looking to install the current version (V3) of Norminette use this version: https://github.com/42School/norminette
+
+---
+
 <h1 align="center"><code>norminette @ home</code></h1>
 
 <div align="center">


### PR DESCRIPTION
This version is no longer used and some students are using this by mistake. Just add a deprecated warning to make sure that everyone use the new version of Norminette.